### PR TITLE
fix: 修复报错 Update FilmList.vue

### DIFF
--- a/client/src/components/FilmList.vue
+++ b/client/src/components/FilmList.vue
@@ -44,7 +44,7 @@ watchEffect(()=>{
   // 如果是PC, 为防止flex布局最后一行元素不足出现错位, 使用空元素补齐list
   let c = isMobile ? 3 : props.col? props.col: 0
   let l:any= props.list
-  let len = l.length
+  let len = l ? l.length : 0
   d.width = isMobile ? 31 : Math.floor(100 / c)
   if (len % c !=0) {
     for (let i = 0; i < c - len %c ; i++) {


### PR DESCRIPTION
fix: 修复报错
FilmList.vue:47 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'length')
    at FilmList.vue:47:3
    at callWithErrorHandling (runtime-core.esm-bundler.js:188:18)
    at callWithAsyncErrorHandling (runtime-core.esm-bundler.js:196:17)
    at ReactiveEffect.getter [as fn] (runtime-core.esm-bundler.js:1871:16)
    at ReactiveEffect.run (reactivity.esm-bundler.js:170:19)
    at job (runtime-core.esm-bundler.js:1933:14)
    at flushPreFlushCbs (runtime-core.esm-bundler.js:342:7)
    at updateComponentPreRender (runtime-core.esm-bundler.js:6136:5)
    at ReactiveEffect.componentUpdateFn [as fn] (runtime-core.esm-bundler.js:6049:11)
    at ReactiveEffect.run (reactivity.esm-bundler.js:170:19)